### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ tests/
 pre-compiled/.spago
 pre-compiled/node_modules
 pre-compiled/output
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ pre-compiled/node_modules
 pre-compiled/output
 .appends
 .gitignore
+.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ pre-compiled/.spago
 pre-compiled/node_modules
 pre-compiled/output
 .appends
+.gitignore


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
