### PR TITLE
Purescript 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the PureScript test runner, which implements the
 
 To run a solution's test in the Docker container, do the following:
 1. Open terminal in project's root
-2. Run `./run-in-docker.sh <exercise> <solution-folder> <output-folder>`
+2. Run `./bin/run-in-docker.sh <exercise> <solution-folder> <output-folder>`
 
 [test-runner-interface]: https://github.com/exercism/automated-tests/blob/master/docs/interface.md
 [web-exercism]: https://exercism.io/

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -25,7 +25,7 @@ for config in "${base_dir}"/tests/*/spago.dhall; do
     expected_results_file="${exercise_dir}/expected_results.json"
     actual_results_file="${exercise_dir}/results.json"
 
-    bin/run.sh "${slug}" "${exercise_dir}" "${exercise_dir}"
+    "${base_dir}"/bin/run.sh "${slug}" "${exercise_dir}" "${exercise_dir}"
 
     echo "${slug}: comparing results.json to expected_results.json"
 

--- a/pre-compiled/package-lock.json
+++ b/pre-compiled/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "agpl-3.0",
       "devDependencies": {
-        "purescript": "0.13.8",
-        "spago": "^0.20.2"
+        "purescript": "^0.14.3",
+        "spago": "^0.20.3"
       }
     },
     "node_modules/ajv": {
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/purescript": {
-      "version": "0.13.8",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.13.8.tgz",
-      "integrity": "sha512-1ZyVEVFLgcEcjPXxJYeVEyYn66DF2DnOLTWzo/K/MrQUF2chdLSyZ8sJpcarWyrz2HxXaubYceYbo5KexKzynA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.3.tgz",
+      "integrity": "sha512-lAzHU/tcmxF4n3YUwUTwG/sIwHzjUq1zsIOBNmaVpbm7hxM+RhOTKMJdwdbTeCjxlilyVPWOLUQ6Exll4DYuMA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1288,9 +1288,9 @@
       "dev": true
     },
     "node_modules/spago": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/spago/-/spago-0.20.2.tgz",
-      "integrity": "sha512-B3TqAK4Uyq39LEeFjtxf5N4Q5kuUX8v68Lyns/8JTSO5VR6zrnxchEjVoUbYXG6lCO3TSj8k30V5s9TBrLmWjQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/spago/-/spago-0.20.3.tgz",
+      "integrity": "sha512-R4CWLP5IbaWoNIpS1QAUuDK2LKlKYqT5gBKVZL7ILilvCwdwS72u3NbGZbvx7VCRRZz4lG7zXUkqKNow7zh6wQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2480,9 +2480,9 @@
       }
     },
     "purescript": {
-      "version": "0.13.8",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.13.8.tgz",
-      "integrity": "sha512-1ZyVEVFLgcEcjPXxJYeVEyYn66DF2DnOLTWzo/K/MrQUF2chdLSyZ8sJpcarWyrz2HxXaubYceYbo5KexKzynA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.3.tgz",
+      "integrity": "sha512-lAzHU/tcmxF4n3YUwUTwG/sIwHzjUq1zsIOBNmaVpbm7hxM+RhOTKMJdwdbTeCjxlilyVPWOLUQ6Exll4DYuMA==",
       "dev": true,
       "requires": {
         "purescript-installer": "^0.2.0"
@@ -2661,9 +2661,9 @@
       "dev": true
     },
     "spago": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/spago/-/spago-0.20.2.tgz",
-      "integrity": "sha512-B3TqAK4Uyq39LEeFjtxf5N4Q5kuUX8v68Lyns/8JTSO5VR6zrnxchEjVoUbYXG6lCO3TSj8k30V5s9TBrLmWjQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/spago/-/spago-0.20.3.tgz",
+      "integrity": "sha512-R4CWLP5IbaWoNIpS1QAUuDK2LKlKYqT5gBKVZL7ILilvCwdwS72u3NbGZbvx7VCRRZz4lG7zXUkqKNow7zh6wQ==",
       "dev": true,
       "requires": {
         "request": "^2.88.0",

--- a/pre-compiled/package.json
+++ b/pre-compiled/package.json
@@ -5,7 +5,7 @@
   "author": "Erik Schierboom",
   "license": "agpl-3.0",
   "devDependencies": {
-    "purescript": "0.13.8",
-    "spago": "^0.20.2"
+    "purescript": "^0.14.3",
+    "spago": "^0.20.3"
   }
 }

--- a/pre-compiled/packages.dhall
+++ b/pre-compiled/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
 
 in  upstream

--- a/pre-compiled/spago.dhall
+++ b/pre-compiled/spago.dhall
@@ -1,4 +1,4 @@
-{ name = "exercise-template"
+{ name = "pre-compiled"
 , dependencies =
   [ "arrays"
   , "console"
@@ -9,13 +9,16 @@
   , "foldable-traversable"
   , "integers"
   , "lists"
+  , "math"
   , "maybe"
   , "ordered-collections"
+  , "partial"
   , "prelude"
   , "psci-support"
   , "strings"
   , "test-unit"
   , "tuples"
+  , "unfoldable"
   , "unicode"
   ]
 , packages = ./packages.dhall

--- a/tests/example-all-fail/packages.dhall
+++ b/tests/example-all-fail/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
 
 in  upstream

--- a/tests/example-all-fail/spago.dhall
+++ b/tests/example-all-fail/spago.dhall
@@ -1,5 +1,10 @@
-{ name = "leap"
-, dependencies = [ "console", "effect", "prelude", "psci-support", "test-unit" ]
+{ name = "example-all-fail"
+, dependencies =
+  [ "effect"
+  , "prelude"
+  , "psci-support"
+  , "test-unit"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/tests/example-empty-file/packages.dhall
+++ b/tests/example-empty-file/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
 
 in  upstream

--- a/tests/example-empty-file/spago.dhall
+++ b/tests/example-empty-file/spago.dhall
@@ -1,5 +1,10 @@
-{ name = "leap"
-, dependencies = [ "console", "effect", "prelude", "psci-support", "test-unit" ]
+{ name = "example-empty-file"
+, dependencies =
+  [ "effect"
+  , "prelude"
+  , "psci-support"
+  , "test-unit"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/tests/example-partial-fail/packages.dhall
+++ b/tests/example-partial-fail/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
 
 in  upstream

--- a/tests/example-partial-fail/spago.dhall
+++ b/tests/example-partial-fail/spago.dhall
@@ -1,5 +1,10 @@
-{ name = "leap"
-, dependencies = [ "console", "effect", "prelude", "psci-support", "test-unit" ]
+{ name = "example-partial-fail"
+, dependencies =
+  [ "effect"
+  , "prelude"
+  , "psci-support"
+  , "test-unit"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/tests/example-success/packages.dhall
+++ b/tests/example-success/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
 
 in  upstream

--- a/tests/example-success/spago.dhall
+++ b/tests/example-success/spago.dhall
@@ -1,5 +1,10 @@
-{ name = "leap"
-, dependencies = [ "console", "effect", "prelude", "psci-support", "test-unit" ]
+{ name = "example-success"
+, dependencies =
+  [ "effect"
+  , "prelude"
+  , "psci-support"
+  , "test-unit"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/tests/example-syntax-error/packages.dhall
+++ b/tests/example-syntax-error/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210226/packages.dhall sha256:7e973070e323137f27e12af93bc2c2f600d53ce4ae73bb51f34eb7d7ce0a43ea
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
 
 in  upstream

--- a/tests/example-syntax-error/spago.dhall
+++ b/tests/example-syntax-error/spago.dhall
@@ -1,5 +1,10 @@
-{ name = "leap"
-, dependencies = [ "console", "effect", "prelude", "psci-support", "test-unit" ]
+{ name = "example-syntax-error"
+, dependencies =
+  [ "effect"
+  , "prelude"
+  , "psci-support"
+  , "test-unit"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }


### PR DESCRIPTION
As discussed in https://github.com/emiel/purescript-test-runner/pull/3, opening a PR in the main repository.

I've checked out updated `exercism/purescript` branch `purescript-0.14` (see https://github.com/exercism/purescript/pull/232) at `~/purescript/purescript-exercism/`.

Running:

```
./bin/run-in-docker.sh hello-world ~/purescript/purescript-exercism/exercises/practice/hello-world/ /tmp
```

produces:

```
{
  "version": 1,
  "status": "fail",
  "message": "[info] Build succeeded.\n[warn] None of your project files import modules from some projects that are in the direct dependencies of your project.\nThese dependencies are unused. To fix this warning, remove the following packages from the list of dependencies in your config:\n- arrays\n- console\n- datetime\n- either\n- enums\n- foldable-traversable\n- integers\n- lists\n- math\n- maybe\n- ordered-collections\n- partial\n- strings\n- tuples\n- unfoldable\n- unicode\n- Suite: HelloWorld.helloWorld\n  ☠ Failed: Hello, World! because expected \"Hello, World!\", got \"Goodbye, Mars!\"\n\n1 test failed:\n\nIn \"HelloWorld.helloWorld\":\n  In \"Hello, World!\":\nError: Error: expected \"Hello, World!\", got \"Goodbye, Mars!\"\n\n[error] Tests failed: exit code: 1"
}
```

This looks expected.

Let me know if this looks good to be merged or if any changes are needed.

