### PR TITLE
Remove action version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # 3.0.2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Run Tests in Docker
         run: bin/run-tests-in-docker.sh


### PR DESCRIPTION
These version comments are not updated by dependabot and thus will become stale. The SHA alone is sufficient and thus we'll remove the version comment. @ErikSchierboom 