### PR TITLE
Upgrade to PureScript 0.14.9 (from 0.14.7)

### DIFF
--- a/pre-compiled/package-lock.json
+++ b/pre-compiled/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "agpl-3.0",
       "devDependencies": {
-        "purescript": "^0.14.7",
+        "purescript": "^0.14.9",
         "spago": "^0.20.9"
       }
     },

--- a/pre-compiled/package.json
+++ b/pre-compiled/package.json
@@ -5,7 +5,7 @@
   "author": "Erik Schierboom",
   "license": "agpl-3.0",
   "devDependencies": {
-    "purescript": "^0.14.7",
+    "purescript": "^0.14.9",
     "spago": "^0.20.9"
   }
 }


### PR DESCRIPTION
- Upgrade to 0.14.9 to resolve libtinfo issue.

- Note that there is no package set for 0.14.9.