### PR TITLE
Sync up purescript and purescript-test-runner packages.dhall

### DIFF
--- a/pre-compiled/packages.dhall
+++ b/pre-compiled/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250205/packages.dhall
-        sha256:442220ce62d4f9a353819b28db9a7295cca7acaae7d2fbe814e52c1b25a7a296
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250421/packages.dhall
+        sha256:17a9c249023117e2efce524240c2b2adc955dccc686dbeb93f9e0e9797767fbf
 
 in  upstream

--- a/tests/example-all-fail/packages.dhall
+++ b/tests/example-all-fail/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250205/packages.dhall
-        sha256:442220ce62d4f9a353819b28db9a7295cca7acaae7d2fbe814e52c1b25a7a296
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250421/packages.dhall
+        sha256:17a9c249023117e2efce524240c2b2adc955dccc686dbeb93f9e0e9797767fbf
 
 in  upstream

--- a/tests/example-empty-file/packages.dhall
+++ b/tests/example-empty-file/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250205/packages.dhall
-        sha256:442220ce62d4f9a353819b28db9a7295cca7acaae7d2fbe814e52c1b25a7a296
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250421/packages.dhall
+        sha256:17a9c249023117e2efce524240c2b2adc955dccc686dbeb93f9e0e9797767fbf
 
 in  upstream

--- a/tests/example-partial-fail/packages.dhall
+++ b/tests/example-partial-fail/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250205/packages.dhall
-        sha256:442220ce62d4f9a353819b28db9a7295cca7acaae7d2fbe814e52c1b25a7a296
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250421/packages.dhall
+        sha256:17a9c249023117e2efce524240c2b2adc955dccc686dbeb93f9e0e9797767fbf
 
 in  upstream

--- a/tests/example-success/packages.dhall
+++ b/tests/example-success/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250205/packages.dhall
-        sha256:442220ce62d4f9a353819b28db9a7295cca7acaae7d2fbe814e52c1b25a7a296
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250421/packages.dhall
+        sha256:17a9c249023117e2efce524240c2b2adc955dccc686dbeb93f9e0e9797767fbf
 
 in  upstream

--- a/tests/example-syntax-error/packages.dhall
+++ b/tests/example-syntax-error/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250205/packages.dhall
-        sha256:442220ce62d4f9a353819b28db9a7295cca7acaae7d2fbe814e52c1b25a7a296
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20250421/packages.dhall
+        sha256:17a9c249023117e2efce524240c2b2adc955dccc686dbeb93f9e0e9797767fbf
 
 in  upstream


### PR DESCRIPTION
This should be merged at the same time as the corresponding purescript psc-0.15.15-20250421 branch merge.