### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Spago 1.0.3 requires Node.js >= 22.5.0 (uses node:sqlite built-in module)
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 # Install system dependencies:
 # - ca-certificates: HTTPS support for downloading packages from the registry


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.
